### PR TITLE
Add steps to run .NET Core test project.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -61,6 +61,15 @@
 			   ParallelizeTestCollections="true"
 			   ContinueOnError="ErrorAndContinue" />
 
+		<Exec ContinueOnError="True" Command="dotnet --info">
+			<Output TaskParameter="ExitCode" PropertyName="DotNetErrorCode"/>
+		</Exec>
+		<Warning Condition="'$(DotNetErrorCode)' != '0'" Text="Error in executing dotnet. Skipping .NET Core tests." />
+		<Exec Condition="'$(DotNetErrorCode)' == '0'"
+			Command="dotnet restore" ContinueOnError="false" />
+		<Exec Condition="'$(DotNetErrorCode)' == '0'"
+			Command="dotnet test UnitTests.NetCore\Moq.NetCore.Tests\project.json -c release -xml $(Out)\test.dotnet.xml" ContinueOnError="false" />
+
 		<!-- This isn't collecting any data right now, so make Coverage == '' by default so it won't run with this condition -->
 		<Exec Command="$(CoverageConsole) $(CoverageOptions) -target:$(XunitConsole) -targetargs:&quot;@(TestAssembly, ' ') $(XunitOptions)&quot;"
 			  Condition=" '$(Coverage)' == 'true' "

--- a/wrap/Moq/project.json
+++ b/wrap/Moq/project.json
@@ -9,7 +9,8 @@
       "bin": {
         "assembly": "../../Source.NetCore/bin/{configuration}/Moq.dll",
         "pdb": "../../Source.NetCore/bin/{configuration}/Moq.pdb"
-      }
+      },
+      "imports": [ "dotnet5.4" ]
     }
   }
 }


### PR DESCRIPTION
Use dotnet to run the .NET Core test project if it exists in PATH.
